### PR TITLE
Amélioration README et ajout chemin Clapi

### DIFF
--- a/Centreon.class.php
+++ b/Centreon.class.php
@@ -11,6 +11,7 @@ private $poller;
 	include ('config.php');
 	$this->user = $config['centreon']['user'];
 	$this->password = $config['centreon']['password'];
+        $this->clapi = $config['centreon']['clapi'];
 	$this->poller = $config['pollers']['poller1'];
 
 	}
@@ -19,19 +20,19 @@ private $poller;
 	 * Methode permettant de recuperer les ip présentes dans centreon
 	 */
 	function getIpHost() {
-	$out = shell_exec('/usr/bin/centreon -u ' . $this->user . ' -p ' . $this->password . '  -o HOST -a show | cut -f4 -d";" |  grep -v "address" ');
+	$out = shell_exec($this->clapi. ' -u ' . $this->user . ' -p ' . $this->password . '  -o HOST -a show | cut -f4 -d";" |  grep -v "address" ');
 	$iptab = preg_split('/\s+/', trim($out));
 	return $iptab;
 
 	}
 
 	function getPollerName() {
-	$out = shell_exec('/usr/bin/centreon -u ' . $this->user . ' -p ' . $this->password . '   -a gettemplate ');
+	$out = shell_exec($this->clapi. ' -u ' . $this->user . ' -p ' . $this->password . '   -a gettemplate ');
 	return $out;
 	}
 
 	function getTemplateName() {
-	 $out = shell_exec ('/usr/bin/centreon -u ' . $this->user . ' -p ' . $this->password . ' -e | egrep -e "^(HTPL)" | cut -f3 -d";" | uniq -d ');
+	 $out = shell_exec ($this->clapi. ' -u ' . $this->user . ' -p ' . $this->password . ' -e | egrep -e "^(HTPL)" | cut -f3 -d";" | uniq -d ');
 	$templateName = preg_split('/\s+/', trim($out));
 	return $templateName;
 	
@@ -40,18 +41,18 @@ private $poller;
 
 	function addHost($ip,$nom,$poller,$template) {
 	
-	$addhost = shell_exec("/usr/bin/centreon -u  $this->user  -p  $this->password  -o HOST -a ADD -v \"$nom;$nom;$ip;$template;$poller;;\" ");
-	$applyTpl = shell_exec("/usr/bin/centreon -u $this->user  -p  $this->password  -o HOST -a applytpl -v \"$nom\" ");
+	$addhost = shell_exec("$this->clapi -u  $this->user  -p  $this->password  -o HOST -a ADD -v \"$nom;$nom;$ip;$template;$poller;;\" ");
+	$applyTpl = shell_exec($this->clapi. " -u $this->user  -p  $this->password  -o HOST -a applytpl -v \"$nom\" ");
 	
 	}
 
 	function setParam($nom,$community,$version) {
-	shell_exec("/usr/bin/centreon -u  $this->user   -p   $this->password   -o HOST -a SETPARAM -v \"$nom;host_snmp_community;$community\"");
-	shell_exec("/usr/bin/centreon -u  $this->user   -p   $this->password   -o HOST -a SETPARAM -v \"$nom;host_snmp_version;$version\"");
+	shell_exec("$this->clapi -u  $this->user   -p   $this->password   -o HOST -a SETPARAM -v \"$nom;host_snmp_community;$community\"");
+	shell_exec("$this->clapi -u  $this->user   -p   $this->password   -o HOST -a SETPARAM -v \"$nom;host_snmp_version;$version\"");
 	}
 
 	function applyCfg() {
-	$result = shell_exec("/usr/bin/centreon -u  $this->user   -p   $this->password  -a APPLYCFG -v \"$this->poller\"");
+	$result = shell_exec("$this->clapi -u  $this->user   -p   $this->password  -a APPLYCFG -v \"$this->poller\"");
 	echo $result;
 	}
 	

--- a/README.md
+++ b/README.md
@@ -5,35 +5,95 @@ ATTENTION, c'est un programme en version très beta!!!
 
 Pour le moment, ce programme fonctionne uniquement pour une solution centreon CES avec le poller sur le même serveur .
 
-##Installation :
-cd /usr/share
+## Installation :
 
-git clone https://github.com/romnvll/Centreon_Discovery.git
+### prerequis
 
-le fichier /opt/rh/httpd24/root/etc/httpd/conf.d/discovery.conf :
-###########################################
-Alias /discovery /usr/share/discovery/
-<LocationMatch ^/discovery/(.*\.php(/.*)?)$>
-   ProxyPassMatch fcgi://127.0.0.1:9043/usr/share/discovery/$1
-</LocationMatch>
-ProxyTimeout 300
-<Directory "/usr/share/discovery">
-    DirectoryIndex index.php
-    Options Indexes
-    AllowOverride all
-    Order allow,deny
-    Allow from all
-    Require all granted
-    <IfModule mod_php5.c>
-        php_admin_value engine Off
-    </IfModule>
-    AddType text/plain hbs
+git
 
-</Directory>
+### mode opératoire
+
+création dossier discovery
+
+	mkdir /usr/share/discovery
+
+récupération du dépôt
+
+	git clone https://github.com/romnvll/Open-Centreon-Discovery.git
+
+**Modification apache pour CentOS**
+
+créer le fichier /opt/rh/httpd24/root/etc/httpd/conf.d/discovery.conf :
+
+	###########################################
+	Alias /discovery /usr/share/discovery/
+	<LocationMatch ^/discovery/(.*\.php(/.*)?)$>
+   		ProxyPassMatch fcgi://127.0.0.1:9043/usr/share/discovery/$1
+	</LocationMatch>
+	ProxyTimeout 300
+	<Directory "/usr/share/discovery">
+    	DirectoryIndex index.php
+    	Options Indexes
+    	AllowOverride all
+    	Order allow,deny
+    	Allow from all
+    	Require all granted
+    	<IfModule mod_php5.c>
+        	php_admin_value engine Off
+    	</IfModule>
+    	AddType text/plain hbs
+
+	</Directory>
 
 
-RedirectMatch ^/$ /discovery
-###########################################
+	RedirectMatch ^/$ /discovery
+	###########################################
+
+adapter le port 904x en fonction de votre configuration, doit être identique à fpm
+
+relancer apache
+
+systemctl restart httpd24-httpd
+
+**Modification apache pour Debian**
+
+créer le fichier /etc/apache2/conf-available/discovery.conf :
+
+	###########################################
+	Alias /discovery /usr/share/discovery/
+	<LocationMatch ^/discovery/(.*\.php(/.*)?)$>
+   		ProxyPassMatch fcgi://127.0.0.1:9042/usr/share/discovery/$1
+	</LocationMatch>
+	ProxyTimeout 300
+	<Directory "/usr/share/discovery">
+    	DirectoryIndex index.php
+    	Options Indexes
+    	AllowOverride all
+    	Order allow,deny
+    	Allow from all
+    	Require all granted
+    	<IfModule mod_php5.c>
+        	php_admin_value engine Off
+    	</IfModule>
+    	AddType text/plain hbs
+
+	</Directory>
+
+
+	RedirectMatch ^/$ /discovery
+	###########################################
+
+adapter le port 904x en fonction de votre configuration, doit être identique à fpm
+
+activer la configuration et relancer apache
+
+a2enconf discovery
+systemctl reload apache2
+
+Copier les fichiers 
+
+	cd Open-Centreon-Discovery
+	cp -r * /usr/share/discovery
 
 Le fichier config.php devra contenir login/mdp de votre plateforme CES + le nom de votre poller 
 

--- a/config.php
+++ b/config.php
@@ -4,13 +4,12 @@
 $config['centreon']['user'] = 'admin';
 $config['centreon']['password'] = 'admin';
 
-
+//chemin de clapi
+$config['centreon']['clapi'] = '/usr/share/centreon/bin/centreon';
 
 //Le nom de votre poller
 //centreon -u admin -p password -a POLLERLIST
 $config['pollers']['poller1']='Central';
-
-
 
 
 


### PR DESCRIPTION
Bonjour Romain,

Voici ma première modification. Tout d'abord le fichier README avec une procédure pour CentOS et Debian. J'ai validé le fonctionnement avec une 19.10. Je vais testé avec la version 20.04 et 20.10 ensuite.
J'ai ajouté une modification pour le chemin de Clapi car sur une version ISO /usr/bin/centreon est un lien symbolique vers /usr/share/centreon/bin/centreon et qui n'existe pas sur une version source compilée.